### PR TITLE
updated aces_dental gift confirmation popup text

### DIFF
--- a/demo/aces_dental/src/html/main.html
+++ b/demo/aces_dental/src/html/main.html
@@ -188,7 +188,7 @@
                                      alt="{{ $parent.gift_success.name }}">
                             </div>
                     <span class="bns_gift_item_name ta_center">
-                        Congratulations! Contact our office to receive your gift!
+                        Congratulations! You'll receive your gift momentarily via SMS.
                     </span>
                         </div>
                     </div>


### PR DESCRIPTION
This is Noah Vito. This is a simple change to a single line of HTML text to make gift confirmations fit with e-gift cards instead of physical gift cards. 

Trello task: https://trello.com/c/NeJajDuv/1494-acesdental-gift-confirmation-message

Please let me know if they will need to do anything on their end, or if the file at '//d3sailplay.cdnvideo.ru/media/assets/assetfile/09528fee37394bf16b8824c159306e6c.js' will update automatically. This is the JS that's loaded by the widget (see screenshot: https://yadi.sk/i/zGabN34VvpHor )