### PR TITLE
fixing 'Tell about LocalTradePros' facebook action text

### DIFF
--- a/demo/ltp/dist/css/sailplay.ltp.css
+++ b/demo/ltp/dist/css/sailplay.ltp.css
@@ -1358,7 +1358,7 @@ hr {
   display: table;
   height: 71px;
   font-size: 14px;
-  font-weight: 400;
+  font-weight: 300;
   line-height: 18px;
   padding-top: 6px;
 }


### PR DESCRIPTION
How it looks right now: https://dl.dropbox.com/s/bod3mjb87wcvad6/2016-11-17%2017.41.40.png?dl=0

How it looks after reducing font-weight to 300 in safari inspector: https://dl.dropbox.com/s/b2veqb2mjeqkpaw/2016-11-17%2017.41.51.png?dl=0

Hopefully this fixes this issue once and for all. 